### PR TITLE
Fixing the module attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "text"
   ],
   "main": "dist/share-this.js",
-  "module": "src/share-this.js",
+  "module": "src/core.js",
   "author": {
     "name": "Massimo Artizzu",
     "email": "maxart.x@gmail.com"


### PR DESCRIPTION
The `module` attribute currently points to a non-existent file. Fixing it by making it point to `src/core.js`