### PR TITLE
add redraw feature, scroll listener and bugfix for variable context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .nyc_output/
+.idea

--- a/readme.md
+++ b/readme.md
@@ -87,6 +87,11 @@ selectionShare.destroy();
 
 A destroyed sharing object can *not* be `init`ialized again.
 
+If you need to redraw the popover for some reason, use the `redraw` method:
+```javascript
+selectionShare.redraw();
+``` 
+
 
 ## Sharers
 

--- a/src/core.js
+++ b/src/core.js
@@ -154,9 +154,13 @@ export default (opts) => {
             return destroyed = true;
         },
         redraw: () => {
+            if (!initialized || destroyed) return false;
+
             const range = getConstrainedRange();
             if (range) drawPopover(range);
             else killPopover();
+
+            return true;
         }
     };
 };

--- a/src/core.js
+++ b/src/core.js
@@ -132,8 +132,8 @@ export default (opts) => {
             }
 
             eventTypes.forEach(addListener);
-            _window.addEventListener("resize", resizeHandler);
-            _window.addEventListener("scroll", scrollHandler);
+            _window.addEventListener("resize", resizeHandler, { passive: true });
+            _window.addEventListener("scroll", scrollHandler, { passive: true });
 
             lifeCycle = lifeCycleFactory(_document);
 

--- a/test/core.js
+++ b/test/core.js
@@ -1,6 +1,7 @@
 /* eslint-disable consistent-return, no-undef, no-unused-expressions */
 import { expect } from "chai";
 import { env } from "jsdom";
+import { spy } from "sinon";
 
 import factory from "../src/core";
 
@@ -24,6 +25,12 @@ describe("Core factory", () => {
             done();
         });
     });
+    it("must create an object with a redraw method", (done) => {
+        init({}, (result) => {
+            expect(result.redraw).to.be.a("function");
+            done();
+        });
+    });
     describe("init", () => {
         it("must return false if the environment doesn't support Selection API", (done) => {
             init({}, (result) => {
@@ -35,7 +42,7 @@ describe("Core factory", () => {
         });
         it("must return true if the instance has been initialized correctly", (done) => {
             init({}, (result) => {
-                global.document.defaultView.getSelection = function getSelection() {};
+                global.document.defaultView.getSelection = fakeGetSelection;
                 const isInitialized = result.init();
                 expect(isInitialized).to.be.true;
                 done();
@@ -43,10 +50,42 @@ describe("Core factory", () => {
         });
         it("must return false if it's been called more than once", (done) => {
             init({}, (result) => {
-                global.document.defaultView.getSelection = function getSelection() {};
+                global.document.defaultView.getSelection = fakeGetSelection;
                 result.init();
                 const isInitialized = result.init();
                 expect(isInitialized).to.be.false;
+                done();
+            });
+        });
+        it("attaches event listeners to window", (done) => {
+            env(fakeHTML, (err, _window) => {
+                expect(err).to.be.null;
+
+                const spyWindowAddEvent = spy(_window, 'addEventListener');
+
+                global.document = _window.document;
+                const result = factory({});
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+
+                expect(spyWindowAddEvent.withArgs("resize"), "addEventListener(resize)").to.have.been.calledOnce;
+                expect(spyWindowAddEvent.withArgs("scroll"), "addEventListener(scroll)").to.have.been.calledOnce;
+                done();
+            });
+        });
+        it("attaches event listeners to document", (done) => {
+            env(fakeHTML, (err, _window) => {
+                expect(err).to.be.null;
+
+                const spyDocumentAddEvent = spy(_window.document, 'addEventListener');
+
+                global.document = _window.document;
+                const result = factory({});
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+
+                documentEventTypes.forEach(name => expect(spyDocumentAddEvent.withArgs(name), `addEventListener(${name})`).to.have.been.calledOnce);
+
                 done();
             });
         });
@@ -61,9 +100,72 @@ describe("Core factory", () => {
         });
         it("must return true if the instance has been initialized", (done) => {
             init({}, (result) => {
-                global.document.defaultView.getSelection = function getSelection() {};
+                global.document.defaultView.getSelection = fakeGetSelection;
                 result.init();
                 const isSuccessful = result.destroy();
+                expect(isSuccessful).to.be.true;
+                done();
+            });
+        });
+        it("detaches event listeners on window", (done) => {
+            env(fakeHTML, (err, _window) => {
+                expect(err).to.be.null;
+
+                const spyWindowAddEvent = spy(_window, 'removeEventListener');
+
+                global.document = _window.document;
+                const result = factory({});
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+                result.destroy();
+
+                expect(spyWindowAddEvent.withArgs("resize"), "removeEventListener(resize)").to.have.been.calledOnce;
+                expect(spyWindowAddEvent.withArgs("scroll"), "removeEventListener(scroll)").to.have.been.calledOnce;
+                done();
+            });
+        });
+        it("detaches event listeners to document", (done) => {
+            env(fakeHTML, (err, _window) => {
+                expect(err).to.be.null;
+
+                const spyDocumentAddEvent = spy(_window.document, 'removeEventListener');
+
+                global.document = _window.document;
+                const result = factory({});
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+                result.destroy();
+
+                documentEventTypes.forEach(name => expect(spyDocumentAddEvent.withArgs(name), `removeEventListener(${name})`).to.have.been.calledOnce);
+
+                done();
+            });
+        });
+    });
+    describe("redraw", () => {
+        it("must return false if the instance hasn't been initialized", (done) => {
+            init({}, (result) => {
+                global.document.defaultView.getSelection = null;
+                const isSuccessful = result.redraw();
+                expect(isSuccessful).to.be.false;
+                done();
+            });
+        });
+        it("must return false if the instance has already been destroyed", (done) => {
+            init({}, (result) => {
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+                result.destroy();
+                const isSuccessful = result.redraw();
+                expect(isSuccessful).to.be.false;
+                done();
+            });
+        });
+        it("must return true if the instance has been initialized", (done) => {
+            init({}, (result) => {
+                global.document.defaultView.getSelection = fakeGetSelection;
+                result.init();
+                const isSuccessful = result.redraw();
                 expect(isSuccessful).to.be.true;
                 done();
             });
@@ -72,6 +174,16 @@ describe("Core factory", () => {
 });
 
 const fakeHTML = "<div>Hello, world!</div>";
+
+const fakeGetSelection = function getSelection() {
+    return {
+        getRangeAt(){
+            return undefined;
+        }
+    };
+};
+
+const documentEventTypes = [ "selectionchange", "mouseup", "touchend", "touchcancel" ];
 
 function init(opts, callback) {
     env(fakeHTML, (err, _window) => {


### PR DESCRIPTION
This PR adds a redraw feature, so that the popup can be redrawn when the selected content changes it's position (e.g. scrolling an parent element). A scroll-listener is included, but sadly that one only triggers when the body scrolls, not when scrolling inside a div takes place. The exposed `redraw` method solves that.

It also changed most functions on the core to arrow-func. Since we use share-this in a react-component, we realized that the reference to the variables can get lost. Sorry for moving that much code around, it's a side effect of switching to arrow-functions.