### PR TITLE
[update] add a warning

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -103,7 +103,11 @@ export default (opts) => {
         const sharers = options.sharers.filter(sharerCheck.bind(null, text, rawText));
 
         if (!sharers.length) {
-            if (popover) killPopover();
+            if (popover) {
+                // eslint-disable-next-line no-console
+                console.warn("share-this: You have not set the sharers here. So we kill the popover.");
+                killPopover();
+            }
             return;
         }
         if (toBeOpened) popover = lifeCycle.createPopover();


### PR DESCRIPTION
When user have not set sharers, there is no popover. But it's not easy to found that. Or maybe they just misspelled it. I think is better to make a warning as a tips.