### PR TITLE
Add CDN usage

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,6 +36,12 @@ Via bower:
 $ bower install share-this
 ```
 
+Via CDN:
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/share-this/dist/share-this.js"></script>
+```
+
 
 ## Usage
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/share-this) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.